### PR TITLE
Controls hide transition

### DIFF
--- a/data/org.github.FreaxMATE.Ojo.glade
+++ b/data/org.github.FreaxMATE.Ojo.glade
@@ -245,7 +245,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -257,7 +257,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
         <child>
@@ -293,223 +293,240 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkScale" id="ojo_seek_bar">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="round_digits">1</property>
-            <property name="draw_value">False</property>
-            <signal name="button-press-event" handler="on_ojo_seek_bar_button_press_event" swapped="no"/>
-            <signal name="button-release-event" handler="on_ojo_seek_bar_button_release_event" swapped="no"/>
-            <signal name="value-changed" handler="on_ojo_seek_bar_value_changed" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
             <property name="position">4</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="ojo_play_box">
+          <object class="GtkRevealer" id="ojo_revealer_controls">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="reveal_child">True</property>
             <child>
-              <object class="GtkButton" id="ojo_fullscreen">
+              <object class="GtkBox" id="ojo_controls">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">img_ojo_fullscreen</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_ojo_fullscreen_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkVolumeButton" id="ojo_volume">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="focus_on_click">False</property>
-                <property name="receives_default">True</property>
-                <property name="relief">none</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
-                <property name="value">1</property>
-                <property name="icons">audio-volume-muted-symbolic
+                <child>
+                  <object class="GtkScale" id="ojo_seek_bar">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="draw_value">False</property>
+                    <signal name="button-press-event" handler="on_ojo_seek_bar_button_press_event" swapped="no"/>
+                    <signal name="button-release-event" handler="on_ojo_seek_bar_button_release_event" swapped="no"/>
+                    <signal name="value-changed" handler="on_ojo_seek_bar_value_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="ojo_play_box">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkButton" id="ojo_fullscreen">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">img_ojo_fullscreen</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="on_ojo_fullscreen_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkVolumeButton" id="ojo_volume">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="focus_on_click">False</property>
+                        <property name="receives_default">True</property>
+                        <property name="relief">none</property>
+                        <property name="orientation">vertical</property>
+                        <property name="icons">audio-volume-muted-symbolic
 audio-volume-high-symbolic
 audio-volume-low-symbolic
 audio-volume-medium-symbolic</property>
-                <signal name="value-changed" handler="on_ojo_volume_value_changed" swapped="no"/>
-                <child internal-child="plus_button">
-                  <object class="GtkButton">
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <property name="relief">none</property>
+                        <signal name="value-changed" handler="on_ojo_volume_value_changed" swapped="no"/>
+                        <child internal-child="plus_button">
+                          <object class="GtkButton">
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="halign">center</property>
+                            <property name="valign">center</property>
+                            <property name="relief">none</property>
+                          </object>
+                        </child>
+                        <child internal-child="minus_button">
+                          <object class="GtkButton">
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="halign">center</property>
+                            <property name="valign">center</property>
+                            <property name="relief">none</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="ojo_playlist">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">img_ojo_playlist</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="on_ojo_playlist_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="ojo_repeat">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">img_ojo_repeat</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="on_ojo_repeat_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="ojo_play_pause">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">img_ojo_play</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="on_ojo_play_pause_clicked" swapped="no"/>
+                        <accelerator key="space" signal="clicked"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="ojo_prev_track">
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">img_ojo_prev_track</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="on_ojo_prev_track_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="ojo_backward">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">img_ojo_prev</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="on_ojo_backward_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">6</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="ojo_stop">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">img_ojo_stop</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="on_ojo_stop_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">7</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="ojo_forward">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">img_ojo_forw</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="on_ojo_forward_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">8</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="ojo_next_track">
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">img_ojo_next_track</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="on_ojo_next_track_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">9</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="ojo_time_lbl">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">10</property>
+                      </packing>
+                    </child>
                   </object>
-                </child>
-                <child internal-child="minus_button">
-                  <object class="GtkButton">
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <property name="relief">none</property>
-                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ojo_playlist">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">img_ojo_playlist</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_ojo_playlist_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ojo_repeat">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">img_ojo_repeat</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_ojo_repeat_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ojo_play_pause">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">img_ojo_play</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_ojo_play_pause_clicked" swapped="no"/>
-                <accelerator key="space" signal="clicked"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ojo_prev_track">
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">img_ojo_prev_track</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_ojo_prev_track_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ojo_backward">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">img_ojo_prev</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_ojo_backward_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ojo_stop">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">img_ojo_stop</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_ojo_stop_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ojo_forward">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">img_ojo_forw</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_ojo_forward_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">8</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ojo_next_track">
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">img_ojo_next_track</property>
-                <property name="relief">none</property>
-                <signal name="clicked" handler="on_ojo_next_track_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">9</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="ojo_time_lbl">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">10</property>
-              </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">6</property>
           </packing>
         </child>
       </object>

--- a/src/main.c
+++ b/src/main.c
@@ -64,6 +64,12 @@ int main(int argc, char **argv)
       ojo_window_media_open_prepare(list, FALSE) ;
    }
    gtk_main() ;
+   if (ojo_settings_get_boolean(ojo_settings->gsettings, "fullscreen") == TRUE)
+   {
+      ojo_settings_set_boolean(ojo_settings->gsettings, "fullscreen", FALSE) ;
+      ojo_settings_set_int(ojo_settings->gsettings, "width", 960) ;
+      ojo_settings_set_int(ojo_settings->gsettings, "height", 540) ;
+   }
    g_settings_sync() ;
    ojo_player_quit() ;
 

--- a/src/ojo-window.c
+++ b/src/ojo-window.c
@@ -192,9 +192,8 @@ void on_ojo_fullscreen_clicked()
       gtk_window_unfullscreen(GTK_WINDOW(window)) ;
       gtk_button_set_image(GTK_BUTTON(fullscreen_button), gtk_image_new_from_icon_name("view-fullscreen", GTK_ICON_SIZE_BUTTON)) ;
       ojo_settings_set_boolean(ojo_settings->gsettings, "fullscreen", FALSE) ;
-      gtk_widget_show (GTK_WIDGET(play_box)) ;
-      gtk_widget_show (GTK_WIDGET(seek_bar)) ;
-      gtk_widget_show (GTK_WIDGET(menu_bar)) ;
+      gtk_revealer_set_reveal_child(revealer_controls, TRUE) ;
+      gtk_widget_show_all (GTK_WIDGET(menu_bar)) ;
    }
    else
    {
@@ -204,8 +203,7 @@ void on_ojo_fullscreen_clicked()
       gtk_window_present(GTK_WINDOW(window)) ;
       gtk_button_set_image (GTK_BUTTON(fullscreen_button), gtk_image_new_from_icon_name("view-restore", GTK_ICON_SIZE_BUTTON)) ;
       ojo_settings_set_boolean(ojo_settings->gsettings, "fullscreen", TRUE) ;
-      gtk_widget_hide (GTK_WIDGET(play_box)) ;
-      gtk_widget_hide (GTK_WIDGET(seek_bar)) ;
+      gtk_revealer_set_reveal_child(revealer_controls, FALSE) ;
       gtk_widget_hide (GTK_WIDGET(menu_bar)) ;
    }
 }
@@ -412,8 +410,8 @@ gboolean timeout_handler(gpointer data)
    if (ojo_settings_get_boolean(ojo_settings->gsettings, "fullscreen"))
    {
       ojo_window_set_cursor_visible(FALSE) ;
-      gtk_widget_hide (GTK_WIDGET(play_box)) ;
-      gtk_widget_hide (GTK_WIDGET(seek_bar)) ;
+      gtk_revealer_set_reveal_child(revealer_controls, FALSE) ;
+      gtk_widget_hide(GTK_WIDGET(menu_bar)) ;
       area.timeout_tag = 0 ;
    }
 	return (area.timeout_tag != 0) ;
@@ -431,8 +429,8 @@ gboolean on_ojo_drawing_area_motion_notify_event(GtkWidget *widget, GdkEventMoti
    if (speed >= 0 && ojo_settings_get_boolean(ojo_settings->gsettings, "fullscreen"))
    {
       ojo_window_set_cursor_visible(TRUE) ;
-      gtk_widget_show (GTK_WIDGET(play_box)) ;
-      gtk_widget_show (GTK_WIDGET(seek_bar)) ;
+      gtk_revealer_set_reveal_child(revealer_controls, TRUE) ;
+      gtk_widget_show_all(GTK_WIDGET(menu_bar)) ;
    }
    area.timeout_tag = g_timeout_add_seconds (3, timeout_handler, NULL) ;
 
@@ -477,8 +475,8 @@ void ojo_window_setup()
    view_menu_showplaylist = GTK_WIDGET(gtk_builder_get_object(builder, "ojo_menu_showplaylist")) ;
    file_menu_open = GTK_WIDGET(gtk_builder_get_object(builder, "ojo_open")) ;
 
+   controls = GTK_WIDGET(gtk_builder_get_object(builder, "ojo_controls")) ;
    play_box = GTK_WIDGET(gtk_builder_get_object(builder, "ojo_play_box")) ;
-
    seek_bar = GTK_SCALE(gtk_builder_get_object(builder, "ojo_seek_bar")) ;
 
    playpause_button = GTK_BUTTON(gtk_builder_get_object(builder, "ojo_play_pause")) ;
@@ -499,6 +497,7 @@ void ojo_window_setup()
    time_label = GTK_LABEL(gtk_builder_get_object(builder, "ojo_time_lbl")) ;
    background_image = GTK_IMAGE(gtk_builder_get_object(builder, "img_ojo_background_image")) ;
 
+   revealer_controls = GTK_REVEALER(gtk_builder_get_object(builder, "ojo_revealer_controls")) ;
    about = GTK_DIALOG(gtk_builder_get_object(builder, "ojo_on_about")) ;
    preferences_dialog = GTK_DIALOG(gtk_builder_get_object(builder, "ojo_preferences_dialog")) ;
    filechooser_dialog = GTK_DIALOG(gtk_builder_get_object(builder, "ojo_filechooser_dialog")) ;

--- a/src/ojo-window.c
+++ b/src/ojo-window.c
@@ -411,7 +411,6 @@ gboolean timeout_handler(gpointer data)
    {
       ojo_window_set_cursor_visible(FALSE) ;
       gtk_revealer_set_reveal_child(revealer_controls, FALSE) ;
-      gtk_widget_hide(GTK_WIDGET(menu_bar)) ;
       area.timeout_tag = 0 ;
    }
 	return (area.timeout_tag != 0) ;
@@ -430,7 +429,6 @@ gboolean on_ojo_drawing_area_motion_notify_event(GtkWidget *widget, GdkEventMoti
    {
       ojo_window_set_cursor_visible(TRUE) ;
       gtk_revealer_set_reveal_child(revealer_controls, TRUE) ;
-      gtk_widget_show_all(GTK_WIDGET(menu_bar)) ;
    }
    area.timeout_tag = g_timeout_add_seconds (3, timeout_handler, NULL) ;
 

--- a/src/ojo-window.h
+++ b/src/ojo-window.h
@@ -35,7 +35,8 @@ GtkMenuItem       *file_menu,
 GtkWidget         *file_menu_open,
                   *view_menu_fullscreen,
                   *view_menu_showplaylist,
-                  *play_box ;
+                  *play_box,
+                  *controls ;
 GtkImage          *background_image ;
 GtkToggleButton   *preferences_dark_mode ,
                   *preferences_border_style,
@@ -57,6 +58,7 @@ GtkBox            *main_box ;
 GtkDialog         *about ;
 GtkDialog         *preferences_dialog ;
 GtkDialog         *filechooser_dialog ;
+GtkRevealer       *revealer_controls ;
 
 struct _area {
 	guint timeout_tag;


### PR DESCRIPTION
This adds a GtkRevealer to enable a smooth hiding transition of the controlbar.