### PR TITLE
use libvlc for mouse motion detection

### DIFF
--- a/data/org.github.FreaxMATE.Ojo.glade
+++ b/data/org.github.FreaxMATE.Ojo.glade
@@ -240,7 +240,6 @@
           <object class="GtkDrawingArea" id="ojo_drawing_area">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <signal name="motion-notify-event" handler="on_ojo_drawing_area_motion_notify_event" swapped="no"/>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -349,6 +348,7 @@
                         <property name="receives_default">True</property>
                         <property name="relief">none</property>
                         <property name="orientation">vertical</property>
+                        <property name="value">1</property>
                         <property name="icons">audio-volume-muted-symbolic
 audio-volume-high-symbolic
 audio-volume-low-symbolic

--- a/src/ojo-player.c
+++ b/src/ojo-player.c
@@ -139,7 +139,7 @@ void ojo_player_tracks_free()
 void ojo_player_media_open (GSList *list, int n_tracks, gboolean add)
 {
    ojo_player_tracks_initialize(list, n_tracks, add) ;
-   libvlc_media_player_set_xwindow(ojo_player->media_player, GDK_WINDOW_XID(gtk_widget_get_window(GTK_WIDGET(drawing_area)))) ;
+   libvlc_media_player_set_xwindow(ojo_player->media_player, gdk_x11_window_get_xid(gtk_widget_get_window(GTK_WIDGET(drawing_area)))) ;
    ojo_playlist_gtk_initialize() ;
    if (!add)
       ojo_player_media_play(0) ;
@@ -273,4 +273,19 @@ libvlc_media_player_t *ojo_player_get_media_player()
    return ojo_player->media_player ;
 }
 
+int ojo_player_get_mousepos_x()
+{
+   int x = 0, y = 0 ;
+
+   libvlc_video_get_cursor(ojo_player->media_player, 0, &x, &y) ;
+   return x ;
+}
+
+int ojo_player_get_mousepos_y()
+{
+   int x = 0, y = 0 ;
+
+   libvlc_video_get_cursor(ojo_player->media_player, 0, &x, &y) ;
+   return y ;
+}
 

--- a/src/ojo-player.h
+++ b/src/ojo-player.h
@@ -62,6 +62,8 @@ void ojo_player_forward() ;
 gboolean ojo_player_end_reached() ;
 int ojo_player_get_media_index() ;
 libvlc_media_player_t *ojo_player_get_media_player() ;
+int ojo_player_get_mousepos_x() ;
+int ojo_player_get_mousepos_y() ;
 
 #endif /* _ojo_player_h_ */
 

--- a/src/ojo-window.c
+++ b/src/ojo-window.c
@@ -416,6 +416,7 @@ gboolean ojo_window_mouse_motion_handler()
       if (abs(new_x-old_x) > mouse_sensitivity || abs(new_y-old_y) > mouse_sensitivity)
       {
          gtk_revealer_set_reveal_child(revealer_controls, TRUE) ;
+         ojo_window_set_cursor_visible(TRUE) ;
          counter = 0 ;
       }
       old_x = ojo_player_get_mousepos_x() ;
@@ -425,6 +426,7 @@ gboolean ojo_window_mouse_motion_handler()
          if (new_x == old_x && new_y == old_y && !ojo_settings_get_boolean(ojo_settings->gsettings, "view-playlist"))
          {
             gtk_revealer_set_reveal_child(revealer_controls, FALSE) ;
+            ojo_window_set_cursor_visible(FALSE) ;
          }
          counter = 0 ;
       }

--- a/src/ojo-window.h
+++ b/src/ojo-window.h
@@ -60,21 +60,14 @@ GtkDialog         *preferences_dialog ;
 GtkDialog         *filechooser_dialog ;
 GtkRevealer       *revealer_controls ;
 
-struct _area {
-	guint timeout_tag;
-   guint32 last_motion_time ;
-   double last_motion_x ;
-   double last_motion_y ;
-} area ;
-
 GSList *list ;
 int n_tracks ;
 gboolean about_dialog_response, media_already_opened, user_input ;
 char time_string[32] ;
 int timeout, window_width, window_height ;
 int64_t duration ;
+int old_x, old_y, mouse_sensitivity ;
 
-gboolean on_ojo_drawing_area_motion_notify_event( GtkWidget *widget, GdkEventMotion *event ) ;
 void ojo_window_media_open_prepare(GSList *uri_list, gboolean add) ;
 void on_ojo_filechooser_add_clicked(void) ;
 void on_ojo_filechooser_open_clicked(void) ;


### PR DESCRIPTION
This PR replaces the window detection using "motion-notify-event" to hide the control bar with the built-in support of libvlc to prevent interfering of gtk and libvlc. This makes hiding the control bar and dvd menu navigation working simultaneously.