### PR TITLE
add random playback button

### DIFF
--- a/data/org.github.FreaxMATE.Ojo.glade
+++ b/data/org.github.FreaxMATE.Ojo.glade
@@ -2,11 +2,6 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkImage" id="image1">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">media-playlist-normal</property>
-  </object>
   <object class="GtkImage" id="img_ojo_apply">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -62,6 +57,11 @@
     <property name="can_focus">False</property>
     <property name="margin_bottom">1</property>
     <property name="stock">gtk-media-previous</property>
+  </object>
+  <object class="GtkImage" id="img_ojo_random">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">media-playlist-normal</property>
   </object>
   <object class="GtkImage" id="img_ojo_repeat">
     <property name="visible">True</property>
@@ -437,7 +437,7 @@ audio-volume-medium-symbolic</property>
                       <object class="GtkButton" id="ojo_random">
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="image">image1</property>
+                        <property name="image">img_ojo_random</property>
                         <property name="relief">none</property>
                         <signal name="clicked" handler="on_ojo_random_clicked" swapped="no"/>
                       </object>

--- a/data/org.github.FreaxMATE.Ojo.glade
+++ b/data/org.github.FreaxMATE.Ojo.glade
@@ -61,12 +61,12 @@
   <object class="GtkImage" id="img_ojo_random">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">media-playlist-normal</property>
+    <property name="icon_name">media-playlist-consecutive-symbolic</property>
   </object>
   <object class="GtkImage" id="img_ojo_repeat">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">media-repeat-none</property>
+    <property name="icon_name">media-playlist-no-repeat-symbolic</property>
   </object>
   <object class="GtkImage" id="img_ojo_stop">
     <property name="visible">True</property>

--- a/data/org.github.FreaxMATE.Ojo.glade
+++ b/data/org.github.FreaxMATE.Ojo.glade
@@ -2,6 +2,11 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">media-playlist-normal</property>
+  </object>
   <object class="GtkImage" id="img_ojo_apply">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -429,6 +434,21 @@ audio-volume-medium-symbolic</property>
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkButton" id="ojo_random">
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">image1</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="on_ojo_random_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">5</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkButton" id="ojo_prev_track">
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
@@ -439,7 +459,7 @@ audio-volume-medium-symbolic</property>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">5</property>
+                        <property name="position">6</property>
                       </packing>
                     </child>
                     <child>
@@ -454,7 +474,7 @@ audio-volume-medium-symbolic</property>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">6</property>
+                        <property name="position">7</property>
                       </packing>
                     </child>
                     <child>
@@ -469,7 +489,7 @@ audio-volume-medium-symbolic</property>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">7</property>
+                        <property name="position">8</property>
                       </packing>
                     </child>
                     <child>
@@ -484,7 +504,7 @@ audio-volume-medium-symbolic</property>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">8</property>
+                        <property name="position">9</property>
                       </packing>
                     </child>
                     <child>
@@ -498,7 +518,7 @@ audio-volume-medium-symbolic</property>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">9</property>
+                        <property name="position">10</property>
                       </packing>
                     </child>
                     <child>
@@ -510,7 +530,7 @@ audio-volume-medium-symbolic</property>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="pack_type">end</property>
-                        <property name="position">10</property>
+                        <property name="position">11</property>
                       </packing>
                     </child>
                   </object>

--- a/data/org.github.FreaxMATE.Ojo.gschema.xml
+++ b/data/org.github.FreaxMATE.Ojo.gschema.xml
@@ -39,6 +39,11 @@
       <summary>If enabled, coverart will be drawn, when available</summary>
       <description>Toggle borders</description>
     </key>
+    <key name='random-playback' type='b'>
+      <default>false</default>
+      <summary>If enabled, next track will be a random one</summary>
+      <description>If enabled, next track will be a random one</description>
+    </key>
     <key name='repeat-mode' type='i'>
       <default>0</default>
       <summary>repeat mode - 0: none, 1: single, 2: all</summary>

--- a/src/ojo-controlbox.c
+++ b/src/ojo-controlbox.c
@@ -250,24 +250,24 @@ void ojo_controlbox_fullscreen_button_set(gboolean fullscreen_mode)
 void ojo_controlbox_repeat_button_set(int repeat_mode)
 {
    if (repeat_mode == 0)
-      gtk_button_set_image(ojo_controlbox->repeat_button,
-                           gtk_image_new_from_icon_name("media-repeat-none", GTK_ICON_SIZE_BUTTON)) ;
+      gtk_button_set_image(ojo_controlbox->repeat_button, gtk_image_new_from_icon_name(
+                           "media-playlist-no-repeat-symbolic", GTK_ICON_SIZE_BUTTON)) ;
    else if (repeat_mode == 1)
       gtk_button_set_image(ojo_controlbox->repeat_button,
-                           gtk_image_new_from_icon_name("media-repeat-track-amarok", GTK_ICON_SIZE_BUTTON)) ;
+                           gtk_image_new_from_icon_name("media-playlist-repeat-song-symbolic", GTK_ICON_SIZE_BUTTON)) ;
    else
       gtk_button_set_image(ojo_controlbox->repeat_button,
-                           gtk_image_new_from_icon_name("media-repeat-all", GTK_ICON_SIZE_BUTTON)) ;
+                           gtk_image_new_from_icon_name("media-playlist-repeat-symbolic", GTK_ICON_SIZE_BUTTON)) ;
 }
 
 void ojo_controlbox_random_button_set(gboolean random)
 {
    random ?
    gtk_button_set_image(ojo_controlbox->random_button,
-                        gtk_image_new_from_icon_name("media-playlist-shuffle", GTK_ICON_SIZE_BUTTON))
+                        gtk_image_new_from_icon_name("media-playlist-shuffle-symbolic", GTK_ICON_SIZE_BUTTON))
    :
    gtk_button_set_image(ojo_controlbox->random_button,
-                        gtk_image_new_from_icon_name("media-playlist-normal", GTK_ICON_SIZE_BUTTON)) ;
+                        gtk_image_new_from_icon_name("media-playlist-consecutive-symbolic", GTK_ICON_SIZE_BUTTON)) ;
 
 }
 

--- a/src/ojo-controlbox.h
+++ b/src/ojo-controlbox.h
@@ -42,18 +42,20 @@ typedef struct _OjoControlBox
                    *next_track_button,
                    *fullscreen_button,
                    *playlist_button,
-                   *repeat_button ;
+                   *repeat_button,
+                   *random_button ;
 } OjoControlBox ;
 
 OjoControlBox *ojo_controlbox_initialize(GtkBuilder *builder) ;
 void ojo_controlbox_show() ;
 void ojo_controlbox_hide() ;
 void ojo_controlbox_free(OjoControlBox *controlbox) ;
-void ojo_controlbox_set_prev_next_track_control_visibility(int n_tracks) ;
+void ojo_controlbox_set_playlist_control_visibility(int n_tracks) ;
 void ojo_controlbox_seek_bar_start() ;
 void ojo_controlbox_set_border_style (gboolean border_style) ;
 void ojo_controlbox_fullscreen_button_set(gboolean fullscreen_mode) ;
 void ojo_controlbox_repeat_button_set(int repeat_mode) ;
+void ojo_controlbox_random_button_set(gboolean random) ;
 
 #endif /* _ojo_controlbox_h_ */
 

--- a/src/ojo-player.c
+++ b/src/ojo-player.c
@@ -35,6 +35,7 @@ OjoPlayer *ojo_player_initialize()
    new->n_tracks = 0 ;
    new->duration = 0 ;
    new->media_index = 0 ;
+   new->rand = g_rand_new () ;
    return new ;
 }
 
@@ -207,6 +208,11 @@ void ojo_player_forward()
 {
    libvlc_media_player_set_position(ojo_player->media_player,
                                     libvlc_media_player_get_position(ojo_player->media_player)+0.05) ;
+}
+
+void ojo_player_random_track()
+{
+   ojo_player_media_play(g_rand_int_range(ojo_player->rand, 0, ojo_player->n_tracks)) ;
 }
 
 int ojo_player_get_n_tracks()

--- a/src/ojo-player.h
+++ b/src/ojo-player.h
@@ -35,6 +35,7 @@ typedef struct _OjoPlayer
    int n_tracks ;
    int64_t duration ;
    int media_index ;
+   GRand *rand ;
 } OjoPlayer ;
 
 OjoPlayer *ojo_player_initialize(void) ;
@@ -50,6 +51,7 @@ void ojo_player_prev_track(void) ;
 void ojo_player_next_track(void) ;
 void ojo_player_backward(void) ;
 void ojo_player_forward(void) ;
+void ojo_player_random_track(void) ;
 
 int ojo_player_get_n_tracks(void) ;
 int64_t ojo_player_get_duration(void) ;

--- a/src/ojo-window.c
+++ b/src/ojo-window.c
@@ -49,7 +49,7 @@ void ojo_window_set_art_cover_image(char *artist, char *album)
 void ojo_window_media_open_prepare(GSList *uri_list, gboolean add)
 {
    n_tracks = g_slist_length(uri_list) ;
-   ojo_controlbox_set_prev_next_track_control_visibility(n_tracks) ;
+   ojo_controlbox_set_playlist_control_visibility(n_tracks) ;
    media_already_opened = TRUE ;
    ojo_player_media_open(uri_list, n_tracks, add) ;
 }
@@ -104,7 +104,7 @@ void on_ojo_filechooser_open_clicked()
    ojo_window_media_open_prepare(list, FALSE) ;
 }
 
-void ojo_window_format_display_for_media () //FIXME: only hide currently-shown widgets
+void ojo_window_format_display_for_media ()
 {
    if (ojo_settings_get_boolean(ojo_settings->gsettings, "view-playlist"))
    {
@@ -258,21 +258,14 @@ void ojo_window_set_view_coverart (gboolean view_coverart)
 
 void ojo_window_set_repeat(int repeat_mode)
 {
-   if (repeat_mode == 0)
-   {
-      ojo_controlbox_repeat_button_set(repeat_mode) ;
-      ojo_settings_set_int(ojo_settings->gsettings, "repeat-mode", 0) ;
-   }
-   else if (repeat_mode == 1)
-   {
-      ojo_controlbox_repeat_button_set(repeat_mode) ;
-      ojo_settings_set_int(ojo_settings->gsettings, "repeat-mode", 1) ;
-   }
-   else
-   {
-      ojo_controlbox_repeat_button_set(repeat_mode) ;
-      ojo_settings_set_int(ojo_settings->gsettings, "repeat-mode", 2) ;
-   }
+   ojo_controlbox_repeat_button_set(repeat_mode) ;
+   ojo_settings_set_int(ojo_settings->gsettings, "repeat-mode", repeat_mode) ;
+}
+
+void ojo_window_set_random(gboolean random)
+{
+   ojo_controlbox_random_button_set(random) ;
+   ojo_settings_set_boolean(ojo_settings->gsettings, "random-playback", random) ;
 }
 
 gboolean ojo_window_mouse_motion_handler()
@@ -341,7 +334,8 @@ void ojo_window_setup()
 
    ojo_playlist = ojo_playlist_initialize (builder) ;
    window = GTK_WINDOW(gtk_builder_get_object(builder, "window_main")) ;
-   gtk_window_set_default_size(window, ojo_settings_get_int(ojo_settings->gsettings, "width"), ojo_settings_get_int(ojo_settings->gsettings, "height")) ;
+   gtk_window_set_default_size(window, ojo_settings_get_int(ojo_settings->gsettings, "width"),
+                                       ojo_settings_get_int(ojo_settings->gsettings, "height")) ;
    window_width = ojo_window_get_width() ;
    window_height = ojo_window_get_height() ;
 
@@ -359,8 +353,10 @@ void ojo_window_setup()
    file_menu_open = GTK_WIDGET(gtk_builder_get_object(builder, "ojo_open")) ;
 
    preferences_dark_mode = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "ojo_preferences_dark_mode")) ;
-   preferences_border_style = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "ojo_preferences_border_style")) ;
-   preferences_view_coverart = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "ojo_preferences_view_coverart")) ;
+   preferences_border_style = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder,
+                                                "ojo_preferences_border_style")) ;
+   preferences_view_coverart = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder,
+                                                 "ojo_preferences_view_coverart")) ;
 
    background_image = GTK_IMAGE(gtk_builder_get_object(builder, "img_ojo_background_image")) ;
 
@@ -375,6 +371,7 @@ void ojo_window_setup()
    ojo_window_set_view_playlist(FALSE) ;
    ojo_window_set_view_coverart(ojo_settings_get_boolean(ojo_settings->gsettings, "view-coverart")) ;
    ojo_window_set_repeat(ojo_settings_get_int(ojo_settings->gsettings, "repeat-mode")) ;
+   ojo_window_set_random(ojo_settings_get_int(ojo_settings->gsettings, "repeat-mode")) ;
    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(view_menu_showplaylist),
                                   ojo_settings_get_boolean(ojo_settings->gsettings, "view-playlist")) ;
 

--- a/src/ojo-window.h
+++ b/src/ojo-window.h
@@ -60,6 +60,7 @@ void ojo_window_seek_bar_start() ;
 void ojo_window_set_view_playlist(gboolean view_playlist) ;
 void ojo_window_set_title(char *trackName) ;
 void ojo_window_set_repeat(int repeat_mode) ;
+void ojo_window_set_random(gboolean random) ;
 void ojo_window_setup(void) ;
 void ojo_window_format_display_for_media(void) ;
 void ojo_window_set_prev_next_track_control_visibility(int n_tracks) ;


### PR DESCRIPTION
This adds a random playback button.
![Peek 2020-01-23 16-44](https://user-images.githubusercontent.com/49864414/72999427-a6a4e280-3dff-11ea-98e5-3a91b1ec818d.gif)
It only appears when listening to more than one track. However, this is does **not shuffle** the playlist it just plays a random track.
In the future we should either make a preferences option to select shuffle/random or just using one method or setting up two buttons. I'd prefer the first method maybe with shuffle preselected.

FreaxMATE